### PR TITLE
solved bug #97

### DIFF
--- a/src/app/pages/currencies/details/coin-overview/coin-overview.component.html
+++ b/src/app/pages/currencies/details/coin-overview/coin-overview.component.html
@@ -63,9 +63,9 @@
       </div>
 
       <div class="align-left label-value">
-        <p *ngIf="!panelOpen">{{ coin.description | slice:0:350 }}<span *ngIf="coin.description.length > 350">...</span>
+        <p *ngIf="!panelOpen" [innerHTML]="coin.description | slice:0:350"><span *ngIf="coin.description.length > 350">...</span>
         </p>
-        <p *ngIf="!!panelOpen">{{ coin.description }}</p>
+        <p *ngIf="!!panelOpen" [innerHTML]="coin.description"></p>
         <div class="align-center" *ngIf="coin.description.length > 350">
           <button mat-icon-button mat-stroked-button (click)="panelOpen = !panelOpen">
             <mat-icon *ngIf="!panelOpen">keyboard_arrow_down</mat-icon>


### PR DESCRIPTION
coin description does not display html tags anymore
HTML content in the field is rendered instead (not taking cut-off tags into account when displaying only the first n chars in a short description) 
https://dev.azure.com/jeffrey/posmn/_workitems/edit/97