### PR TITLE
Hotfix/bug91

### DIFF
--- a/src/app/pages/currencies/details/shared/overview-exchanges/overview-exchanges.component.ts
+++ b/src/app/pages/currencies/details/shared/overview-exchanges/overview-exchanges.component.ts
@@ -48,16 +48,39 @@ export class OverviewExchangesComponent implements OnInit, OnDestroy {
     this.loader.show(this.loadingKey);
     this.sub = this.coinInfoService.getCoinExchanges(this.coin.id)
       .pipe(
+
         finalize(() => this.loader.hide(this.loadingKey)),
         tap(coinExchanges => {
+
           if (this.limit) {
             coinExchanges = coinExchanges.slice(0, this.limit);
           }
+          // From the data that is left, see to it that coinExchange url's are fixed:
+          coinExchanges = this.createCoinExchangeURLs(coinExchanges);
+
           this.coinExchanges = new MatTableDataSource(coinExchanges);
           this.setDataSourceAttributes();
         }),
       )
       .subscribe();
+  }
+
+    /**
+     *  transform the data as retrieved from the request
+     *  possible other approach is to do it on the fly
+     *  after a user has clicked on the market/pair.
+     *
+     *  When more exchanges need 'personal care' they can be added here in this method,
+     *  but then the method should be renamed to something more general (polishResultExchangeData)
+     */
+  createCoinExchangeURLs(exchanges) {
+    return exchanges.map(function(market){
+        if (market.exchangeIdentifier == "coin_exchange") {
+          market.url = `https://www.coinexchange.io/market/${market.base}/${market.target}`;
+        }
+        return market;
+    });
+    return exchanges;
   }
 
   goToExchange(url: string) {

--- a/src/app/pages/currencies/details/shared/overview-exchanges/overview-exchanges.component.ts
+++ b/src/app/pages/currencies/details/shared/overview-exchanges/overview-exchanges.component.ts
@@ -52,6 +52,9 @@ export class OverviewExchangesComponent implements OnInit, OnDestroy {
         finalize(() => this.loader.hide(this.loadingKey)),
         tap(coinExchanges => {
 
+          // First filter the 'dead' markets out (isStale)
+          coinExchanges = coinExchanges.filter(market => !market.isStale)
+
           if (this.limit) {
             coinExchanges = coinExchanges.slice(0, this.limit);
           }


### PR DESCRIPTION
Fixed bug #91 and #92

#91: (the missing coinExchange URL's) `market.url`

#92: Took the liberty to strip out the markets flagged as stale ~old (dead) `market.isStale: true`

Because: produces a smaller better digestable list with actual current data.
- practically nobody will look at this old marketdata, in the case that one day it appears to come in handy after all it's better anyway to show dead markets optionally.

It appears cryptopia markets are now indicated as market.isStale so issue #92 is resolved as well :-)
